### PR TITLE
fix: spelling error in function name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export default async function yoOptionOrPromt(prompts) {
+export default async function yoOptionOrPrompt(prompts) {
   const isArray = Array.isArray(prompts);
   if (!isArray) prompts = [prompts];
   const filteredPrompts = [];


### PR DESCRIPTION
- I don't think the spelling error was intended.
- Fixes: #1 